### PR TITLE
Correct str format for 404 error

### DIFF
--- a/software_mentions_client/client.py
+++ b/software_mentions_client/client.py
@@ -644,7 +644,7 @@ class software_mentions_client(object):
             elif response.status_code >= 500:
                 logging.error('[{0}] Server Error '.format(response.status_code) + file_in)
             elif response.status_code == 404:
-                logging.error('[{0}] URL not found: [{1}] '.format(response.status_code + url))
+                logging.error('[{0}] URL not found: [{1}] '.format(response.status_code, url))
             elif response.status_code >= 400:
                 logging.error('[{0}] Bad Request'.format(response.status_code))
                 logging.error(response.content)


### PR DESCRIPTION
I believe the logging string formatting for a 404 error is incorrect. In addition, I think this will throw an error, because `status_code` is an integer and `url` a string.